### PR TITLE
Fixed type hints for floats

### DIFF
--- a/private/hints.nim
+++ b/private/hints.nim
@@ -14,18 +14,18 @@ type
           ythOF, ythOFF,
     ythT, ythTR, ythTRU, ythTRUE,
     ythY, ythYE, ythYES,
-    
+
     ythPoint, ythPointI, ythPointIN, ythPointINF,
               ythPointN, ythPointNA, ythPointNAN,
-    
+
     ythLowerFA, ythLowerFAL, ythLowerFALS,
     ythLowerNU, ythLowerNUL,
     ythLowerOF,
     ythLowerTR, ythLowerTRU,
     ythLowerYE,
-    
+
     ythPointLowerIN, ythPointLowerN, ythPointLowerNA,
-    
+
     ythMinus, yth0, ythInt, ythDecimal, ythNumE, ythNumEPlusMinus, ythExponent
 
 macro typeHintStateMachine(c: untyped, content: untyped): stmt =
@@ -33,7 +33,7 @@ macro typeHintStateMachine(c: untyped, content: untyped): stmt =
   result = newNimNode(nnkCaseStmt, content).add(copyNimNode(c))
   for branch in content.children:
     assert branch.kind == nnkOfBranch
-    var 
+    var
       charBranch = newNimNode(nnkOfBranch, branch)
       i = 0
       stateBranches = newNimNode(nnkCaseStmt, branch).add(
@@ -77,6 +77,7 @@ template advanceTypeHint(ch: char) {.dirty.} =
   of '0':
     [ythInitial, ythMinus]      => yth0
     [ythNumE, ythNumEPlusMinus] => ythExponent
+    [ythInt, ythDecimal, ythExponent] => nil
   of '1'..'9':
     [ythInitial, ythMinus]            => ythInt
     [ythNumE, ythNumEPlusMinus]       => ythExponent


### PR DESCRIPTION
I added the rule

```nim
[ythInt, ythDecimal, ythExponent] => nil
```

when matching a `0` in the type hint state machine.

Without this rule, parsing floats would fail on numbers such as `1.0`.

(If everything is ok and you accept the PR, would you mind also publishing version 0.6.2? I am currently blocked by this bug)