### PR TITLE
fix #40

### DIFF
--- a/yaml/hints.nim
+++ b/yaml/hints.nim
@@ -71,8 +71,8 @@ type
     ythAfterTimeSpace, ythAfterTimeZ, ythAfterTimePlusMinus, ythTzHour1,
     ythTzHour2, ythTzHourColon, ythTzMinute1, ythTzMinute2
 
-macro typeHintStateMachine(c: untyped, content: untyped): typed =
-  yAssert content.kind == nnkStmtList
+macro typeHintStateMachine(c: untyped, content: varargs[untyped]): typed =
+  yAssert content.kind == nnkArgList
   result = newNimNode(nnkCaseStmt, content).add(copyNimNode(c))
   for branch in content.children:
     yAssert branch.kind == nnkOfBranch


### PR DESCRIPTION
There was a small change in the parsing logic introduced in Nim 0.17.0.

Macros like `typeHintStateMachine` will no longer receive all of their parameters packed in a single `nnkStmtList`. Instead each `of` branch will be supplied as a separate param, which is consistent with other forms such `else` branches, `do` blocks and so on.

This pull requests deals with this breaking change in Nim 0.17.0