### PR TITLE
Fix for newer versions of compiler.

### DIFF
--- a/yaml/parser.nim
+++ b/yaml/parser.nim
@@ -414,6 +414,8 @@ macro parserState(name: untyped, impl: untyped): typed =
     nameId = newIdentNode("state" & capitalize(nameStr))
   var procImpl = quote do:
     debug("state: " & `nameStr`)
+  if procImpl.kind == nnkStmtList and procImpl.len == 1: procImpl = procImpl[0]
+  procImpl = newStmtList(procImpl)
   procImpl.add(newLetStmt(ident("c"), newCall("ParserContext", ident("s"))))
   procImpl.add(newAssignment(newIdentNode("result"), newLit(false)))
   assert impl.kind == nnkStmtList

--- a/yaml/serialization.nim
+++ b/yaml/serialization.nim
@@ -678,6 +678,8 @@ proc ifNotTransient(tSym: NimNode, fieldIndex: int, content: openarray[NimNode],
   result = quote do:
     when `tSym` == -1 or `fieldIndex` notin transientVectors[`tSym`]:
       `stmts`
+  if result.kind == nnkStmtList and result.len == 1: result = result[0]
+  result = newStmtList(result)
   if elseError:
     result[0].add(newNimNode(nnkElse).add(quote do:
       raise constructionError(`s`, "While constructing " & `tName` &
@@ -692,6 +694,8 @@ macro ensureAllFieldsPresent(s: YamlStream, t: typedesc, tIndex: int, o: typed,
   result = quote do:
     when compiles(`dbp`(`t`)):
       const `defaultValues` = `defaultValueGetter`(`t`)
+  if result.kind == nnkStmtList and result.len == 1: result = result[0]
+  result = newStmtList(result)
   let
     tDecl = getType(t)
     tName = $tDecl[1]


### PR DESCRIPTION
61720e0df9475af647de171f6b2964c36234961a in the Nim compiler introduced the bug
in this project. In brief, the upstream change flattens `nnkStmtList`s of one
item. Thus, `quote do:` followed by one statement is no longer a nnkStmtList
but whatever that one statement is. This breaks several macro implementations
where a `quote do:` form is initialized and then appended to. Based on Araq's
feedback (https://irclogs.nim-lang.org/02-10-2017.html#21:01:26), these
single-statement quotes are now converted into one-element statement lists as
necessary (behavior on old versions of the compiler is maintained).