### PR TITLE
Fix compilation in debug mode

### DIFF
--- a/yaml/private/internal.nim
+++ b/yaml/private/internal.nim
@@ -4,7 +4,7 @@
 #    See the file "copying.txt", included in this
 #    distribution, for details about the copyright.
 
-template internalError*(s: string) =
+proc internalError*(s: string) =
   when not defined(release):
     let ii = instantiationInfo()
     echo "[NimYAML] Error in file ", ii.filename, " at line ", ii.line, ":"


### PR DESCRIPTION
I investigated a build issue with @dom96 and fixed it by changing `internalError` from a template to a proc.

This is untested in real world use cases, I don't know if it breaks things; please test first before merging.