### PR TITLE
Fix code for v0.19.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,8 @@ nim build # build a library
 NimYAML needs at least Nim 0.17.0 in order to compile. Version 0.9.1
 is the last release to support 0.15.x and 0.16.0.
 
+When debugging crashes in this library, use the `d:debug` compile flag to enable printing of the internal stack traces for calls to `internalError` and `yAssert`.
+
 ## License
 
 [MIT][2]

--- a/test/tparser.nim
+++ b/test/tparser.nim
@@ -76,7 +76,7 @@ macro genTests(): untyped =
   let errorTests = toSet(staticExec("cd " & (absolutePath / "tags" / "error") &
                          " && ls -1d *").splitLines())
   let ignored = toSet(["3MYT", "JDH8", "2EBW", "9KAX", "AB8U", "B63P", "FBC9",
-                       "Q5MG", ".git", "name", "tags", "meta"])
+                       "Q5MG", "S98Z", ".git", "name", "tags", "meta"])
 
   result = newStmtList()
   # walkDir for some crude reason does not work with travis build

--- a/test/tquickstart.nim
+++ b/test/tquickstart.nim
@@ -120,8 +120,7 @@ proc testsFor(path: string, root: bool = true, titlePrefix: string = ""):
       test.add(newCall("doAssert", newCall("outputTest", newLit(baseDir),
           newLit(path))))
     else:
-      echo "Error: neither 01-in.yaml nor 01-out.yaml exists in " & path & '!'
-      quit 1
+      error("Error: neither 01-in.yaml nor 01-out.yaml exists in " & path & '!')
     result.add(test)
   for kind, childPath in walkDir(path):
     if kind == pcDir:

--- a/test/tserialization.nim
+++ b/test/tserialization.nim
@@ -400,7 +400,7 @@ suite "Serialization":
     var result: Person
     load(input, result)
     assert result.firstnamechar == 'P'
-    assert result.surname   == "Pan"
+    assert result.surname == "Pan"
     assert result.age == 12
 
   test "Dump custom object":
@@ -447,8 +447,8 @@ suite "Serialization":
     var result: Person
     load(input, result)
     assert result.firstnamechar == 'P'
-    assert result.surname   == "Pan"
-    assert result.age       == 12
+    assert result.surname == "Pan"
+    assert result.age == 12
 
   test "Dump custom object with explicit root tag":
     let input = Person(firstnamechar: 'P', surname: "Pan", age: 12)

--- a/test/tserialization.nim
+++ b/test/tserialization.nim
@@ -205,17 +205,6 @@ suite "Serialization":
     assert result[3] == NegInf
     assert classify(result[4]) == fcNan
 
-  #test "Load nil string":
-  #  let input = "!<tag:nimyaml.org,2016:nil:string> \"\""
-  #  var result: string
-  #  load(input, result)
-  #  assert result.len == 0
-  #
-  #test "Dump nil string":
-  #  let input: string = ""
-  #  var output = dump(input, tsNone, asTidy, blockOnly)
-  #  assertStringEqual yamlDirs & "\n!n!nil:string \"\"", output
-
   test "Load timestamps":
     let input = "[2001-12-15T02:59:43.1Z, 2001-12-14t21:59:43.10-05:00, 2001-12-14 21:59:43.10-5]"
     var result: seq[Time]
@@ -236,17 +225,6 @@ suite "Serialization":
     var input = @["a", "b"]
     var output = dump(input, tsNone, asTidy, blockOnly)
     assertStringEqual yamlDirs & "\n- a\n- b", output
-
-  #test "Load nil seq":
-  #  let input = "!<tag:nimyaml.org,2016:nil:seq> \"\""
-  #  var result: seq[int]
-  #  load(input, result)
-  #  assert result.len == 0
-  #
-  #test "Dump nil seq":
-  #  let input: seq[int] = @[]
-  #  var output = dump(input, tsNone, asTidy, blockOnly)
-  #  assertStringEqual yamlDirs & "\n!n!nil:seq \"\"", output
 
   test "Load char set":
     let input = "- a\n- b"
@@ -640,31 +618,6 @@ next:
     assert result.b == "bcd"
     assert result.c == "cde"
     assert result.d == "d"
-
-  #when not defined(JS):
-  #  test "Load nil values":
-  #    let input = "- ~\n- !!str ~"
-  #    var result: seq[ref string]
-  #    try: load(input, result)
-  #    except YamlConstructionError:
-  #      let ex = (ref YamlConstructionError)(getCurrentException())
-  #      echo "line ", ex.line, ", column ", ex.column, ": ", ex.msg
-  #      echo ex.lineContent
-  #      raise ex
-  #
-  #    assert(result.len == 2)
-  #    assert(result[0] == nil)
-  #    assert(result[1][] == "~")
-  #
-  #  test "Dump nil values":
-  #    var input = newSeq[ref string]()
-  #    input.add(nil)
-  #    input.add(new string)
-  #    input[1][] = "~"
-  #    var output = dump(input, tsRootOnly, asTidy, blockOnly)
-  #    assertStringEqual(yamlDirs &
-  #        "!n!system:seq(tag:yaml.org;2002:str) \n- !!null ~\n- !!str ~",
-  #        output)
 
   test "Custom constructObject":
     let input = "- 1\n- !test:BetterInt 2"

--- a/test/tserialization.nim
+++ b/test/tserialization.nim
@@ -96,30 +96,30 @@ proc constructObject*(s: var YamlStream, c: ConstructionContext,
   constructScalarItem(s, item, BetterInt):
     result = BetterInt(parseBiggestInt(item.scalarContent) + 1)
 
-template assertStringEqual(expected, actual: string, file = stdout) =
+template assertStringEqual(expected, actual: string) =
   if expected != actual:
     # if they are unequal, walk through the strings and check each
     # character for a better error message
     if expected.len != actual.len:
-      file.write "Expected and actual string's length differs.\n"
-      file.write "Expected length: ", expected.len, "\n"
-      file.write "Actual length: ", actual.len, "\n"
+      echo "Expected and actual string's length differs.\n"
+      echo "Expected length: ", expected.len, "\n"
+      echo "Actual length: ", actual.len, "\n"
     # check length up to smaller of the two strings
     for i in countup(0, min(expected.high, actual.high)):
       if expected[i] != actual[i]:
-        file.write "string mismatch at character #", i, "(expected:\'",
+        echo "string mismatch at character #", i, "(expected:\'",
          expected[i], "\', was \'", actual[i], "\'):\n"
-        file.write "expected:\n", expected, "\nactual:\n", actual, "\n"
+        echo "expected:\n", expected, "\nactual:\n", actual, "\n"
         assert(false)
     # if we haven't raised an assertion error here, the problem is that
     # one string is longer than the other
     let minInd = min(expected.len, actual.len) # len instead of high to continue
                                                # after shorter string
     if expected.high > actual.high:
-      file.write "Expected continues with: '", expected[minInd .. ^1], "'"
+      echo "Expected continues with: '", expected[minInd .. ^1], "'"
       assert false
     else:
-      file.write "Actual continues with: '", actual[minInd .. ^1], "'"
+      echo "Actual continues with: '", actual[minInd .. ^1], "'"
       assert false
 
 template expectConstructionError(li, co: int, message: string, body: typed) =
@@ -142,19 +142,6 @@ proc newNode(v: string): ref Node =
 let blockOnly = defineOptions(style=psBlockOnly)
 
 suite "Serialization":
-  test "Internal string assert":
-    let s1 = "foo"
-    let s2 = "foobar"
-    let fname = "dump.txt"
-    let f: File = open(fname, fmWrite)
-    try:
-      assertStringEqual(s1, s2, file=f)
-    except AssertionError:
-      discard
-    finally:
-      f.close()
-      removeFile(fname)
-
   test "Load integer without fixed length":
     var input = "-4247"
     var result: int

--- a/test/tserialization.nim
+++ b/test/tserialization.nim
@@ -205,16 +205,16 @@ suite "Serialization":
     assert result[3] == NegInf
     assert classify(result[4]) == fcNan
 
-  test "Load nil string":
-    let input = "!<tag:nimyaml.org,2016:nil:string> \"\""
-    var result: string
-    load(input, result)
-    assert isNil(result)
-
-  test "Dump nil string":
-    let input: string = nil
-    var output = dump(input, tsNone, asTidy, blockOnly)
-    assertStringEqual yamlDirs & "\n!n!nil:string \"\"", output
+  #test "Load nil string":
+  #  let input = "!<tag:nimyaml.org,2016:nil:string> \"\""
+  #  var result: string
+  #  load(input, result)
+  #  assert result.len == 0
+  #
+  #test "Dump nil string":
+  #  let input: string = ""
+  #  var output = dump(input, tsNone, asTidy, blockOnly)
+  #  assertStringEqual yamlDirs & "\n!n!nil:string \"\"", output
 
   test "Load timestamps":
     let input = "[2001-12-15T02:59:43.1Z, 2001-12-14t21:59:43.10-05:00, 2001-12-14 21:59:43.10-5]"
@@ -237,16 +237,16 @@ suite "Serialization":
     var output = dump(input, tsNone, asTidy, blockOnly)
     assertStringEqual yamlDirs & "\n- a\n- b", output
 
-  test "Load nil seq":
-    let input = "!<tag:nimyaml.org,2016:nil:seq> \"\""
-    var result: seq[int]
-    load(input, result)
-    assert isNil(result)
-
-  test "Dump nil seq":
-    let input: seq[int] = nil
-    var output = dump(input, tsNone, asTidy, blockOnly)
-    assertStringEqual yamlDirs & "\n!n!nil:seq \"\"", output
+  #test "Load nil seq":
+  #  let input = "!<tag:nimyaml.org,2016:nil:seq> \"\""
+  #  var result: seq[int]
+  #  load(input, result)
+  #  assert result.len == 0
+  #
+  #test "Dump nil seq":
+  #  let input: seq[int] = @[]
+  #  var output = dump(input, tsNone, asTidy, blockOnly)
+  #  assertStringEqual yamlDirs & "\n!n!nil:seq \"\"", output
 
   test "Load char set":
     let input = "- a\n- b"
@@ -641,30 +641,30 @@ next:
     assert result.c == "cde"
     assert result.d == "d"
 
-  when not defined(JS):
-    test "Load nil values":
-      let input = "- ~\n- !!str ~"
-      var result: seq[ref string]
-      try: load(input, result)
-      except YamlConstructionError:
-        let ex = (ref YamlConstructionError)(getCurrentException())
-        echo "line ", ex.line, ", column ", ex.column, ": ", ex.msg
-        echo ex.lineContent
-        raise ex
-
-      assert(result.len == 2)
-      assert(result[0] == nil)
-      assert(result[1][] == "~")
-
-    test "Dump nil values":
-      var input = newSeq[ref string]()
-      input.add(nil)
-      input.add(new string)
-      input[1][] = "~"
-      var output = dump(input, tsRootOnly, asTidy, blockOnly)
-      assertStringEqual(yamlDirs &
-          "!n!system:seq(tag:yaml.org;2002:str) \n- !!null ~\n- !!str ~",
-          output)
+  #when not defined(JS):
+  #  test "Load nil values":
+  #    let input = "- ~\n- !!str ~"
+  #    var result: seq[ref string]
+  #    try: load(input, result)
+  #    except YamlConstructionError:
+  #      let ex = (ref YamlConstructionError)(getCurrentException())
+  #      echo "line ", ex.line, ", column ", ex.column, ": ", ex.msg
+  #      echo ex.lineContent
+  #      raise ex
+  #
+  #    assert(result.len == 2)
+  #    assert(result[0] == nil)
+  #    assert(result[1][] == "~")
+  #
+  #  test "Dump nil values":
+  #    var input = newSeq[ref string]()
+  #    input.add(nil)
+  #    input.add(new string)
+  #    input[1][] = "~"
+  #    var output = dump(input, tsRootOnly, asTidy, blockOnly)
+  #    assertStringEqual(yamlDirs &
+  #        "!n!system:seq(tag:yaml.org;2002:str) \n- !!null ~\n- !!str ~",
+  #        output)
 
   test "Custom constructObject":
     let input = "- 1\n- !test:BetterInt 2"

--- a/test/tserialization.nim
+++ b/test/tserialization.nim
@@ -97,7 +97,7 @@ proc constructObject*(s: var YamlStream, c: ConstructionContext,
     result = BetterInt(parseBiggestInt(item.scalarContent) + 1)
 
 template assertStringEqual(expected, actual: string) =
-  for i in countup(0, min(expected.len, actual.len)):
+  for i in countup(0, min(expected.len, actual.len) - 1):
     if expected[i] != actual[i]:
       echo "string mismatch at character #", i, "(expected:\'",
             expected[i], "\', was \'", actual[i], "\'):"

--- a/test/tserialization.nim
+++ b/test/tserialization.nim
@@ -5,7 +5,7 @@
 #    distribution, for details about the copyright.
 
 import "../yaml"
-import unittest, strutils, tables, times, math
+import unittest, strutils, tables, times, math, os
 
 type
   MyTuple = tuple
@@ -96,13 +96,31 @@ proc constructObject*(s: var YamlStream, c: ConstructionContext,
   constructScalarItem(s, item, BetterInt):
     result = BetterInt(parseBiggestInt(item.scalarContent) + 1)
 
-template assertStringEqual(expected, actual: string) =
-  for i in countup(0, min(expected.len, actual.len) - 1):
-    if expected[i] != actual[i]:
-      echo "string mismatch at character #", i, "(expected:\'",
-            expected[i], "\', was \'", actual[i], "\'):"
-      echo "expected:\n", expected, "\nactual:\n", actual
-      assert(false)
+template assertStringEqual(expected, actual: string, file = stdout) =
+  if expected != actual:
+    # if they are unequal, walk through the strings and check each
+    # character for a better error message
+    if expected.len != actual.len:
+      file.write "Expected and actual string's length differs.\n"
+      file.write "Expected length: ", expected.len, "\n"
+      file.write "Actual length: ", actual.len, "\n"
+    # check length up to smaller of the two strings
+    for i in countup(0, min(expected.high, actual.high)):
+      if expected[i] != actual[i]:
+        file.write "string mismatch at character #", i, "(expected:\'",
+         expected[i], "\', was \'", actual[i], "\'):\n"
+        file.write "expected:\n", expected, "\nactual:\n", actual, "\n"
+        assert(false)
+    # if we haven't raised an assertion error here, the problem is that
+    # one string is longer than the other
+    let minInd = min(expected.len, actual.len) # len instead of high to continue
+                                               # after shorter string
+    if expected.high > actual.high:
+      file.write "Expected continues with: '", expected[minInd .. ^1], "'"
+      assert false
+    else:
+      file.write "Actual continues with: '", actual[minInd .. ^1], "'"
+      assert false
 
 template expectConstructionError(li, co: int, message: string, body: typed) =
   try:
@@ -124,6 +142,19 @@ proc newNode(v: string): ref Node =
 let blockOnly = defineOptions(style=psBlockOnly)
 
 suite "Serialization":
+  test "Internal string assert":
+    let s1 = "foo"
+    let s2 = "foobar"
+    let fname = "dump.txt"
+    let f: File = open(fname, fmWrite)
+    try:
+      assertStringEqual(s1, s2, file=f)
+    except AssertionError:
+      discard
+    finally:
+      f.close()
+      removeFile(fname)
+
   test "Load integer without fixed length":
     var input = "-4247"
     var result: int

--- a/test/tserialization.nim
+++ b/test/tserialization.nim
@@ -5,7 +5,7 @@
 #    distribution, for details about the copyright.
 
 import "../yaml"
-import unittest, strutils, tables, times, math, os
+import unittest, strutils, tables, times, math
 
 type
   MyTuple = tuple

--- a/test/tserialization.nim
+++ b/test/tserialization.nim
@@ -505,9 +505,9 @@ suite "Serialization":
     let input = "{b: b, d: d}"
     var result: NonVariantWithTransient
     load(input, result)
-    assert isNil(result.a)
+    assert result.a.len == 0
     assert result.b == "b"
-    assert isNil(result.c)
+    assert result.c.len == 0
     assert result.d == "d"
 
   test "Load non-variant object with transient fields - unknown field":

--- a/yaml.nim
+++ b/yaml.nim
@@ -38,7 +38,8 @@
 ## * The hints API in `hints <yaml.hints.html>`_ provides a simple proc for
 ##   guessing the type of a scalar value.
 
-import yaml.dom, yaml.hints, yaml.parser, yaml.presenter,
-       yaml.serialization, yaml.stream, yaml.taglib, yaml.tojson
-export yaml.dom, yaml.hints, yaml.parser, yaml.presenter,
-       yaml.serialization, yaml.stream, yaml.taglib, yaml.tojson
+import yaml / [dom, hints, parser, presenter,
+               serialization, stream, taglib, tojson]
+
+export dom, hints, parser, presenter,
+       serialization, stream, taglib, tojson

--- a/yaml/parser.nim
+++ b/yaml/parser.nim
@@ -158,7 +158,7 @@ proc currentScalar(c: ParserContext, e: var YamlStreamEvent)
   e = YamlStreamEvent(kind: yamlScalar, scalarTag: c.tag,
                       scalarAnchor: c.anchor)
   shallowCopy(e.scalarContent, c.lex.buf)
-  c.lex.buf = cast[string not nil](newStringOfCap(256))
+  c.lex.buf = cast[string](newStringOfCap(256))
   c.tag = yTagQuestionMark
   c.anchor = yAnchorNone
 

--- a/yaml/parser.nim
+++ b/yaml/parser.nim
@@ -158,7 +158,7 @@ proc currentScalar(c: ParserContext, e: var YamlStreamEvent)
   e = YamlStreamEvent(kind: yamlScalar, scalarTag: c.tag,
                       scalarAnchor: c.anchor)
   shallowCopy(e.scalarContent, c.lex.buf)
-  c.lex.buf = cast[string](newStringOfCap(256))
+  c.lex.buf = newStringOfCap(256)
   c.tag = yTagQuestionMark
   c.anchor = yAnchorNone
 

--- a/yaml/private/internal.nim
+++ b/yaml/private/internal.nim
@@ -15,9 +15,9 @@ template internalError*(s: string) =
       echo "[NimYAML] Stacktrace:"
       try:
         writeStackTrace()
-        when defined(debug):
-          echo "Internal stacktrace:"
-          let exc = getCurrentException()
+        echo "Internal stacktrace:"
+        let exc = getCurrentException()
+        if not isNil(exc.parent):
           echo getStackTrace(exc.parent)
       except: discard
     echo "[NimYAML] Please report this bug."
@@ -33,9 +33,9 @@ template yAssert*(e: typed) =
         echo "[NimYAML] Stacktrace:"
         try:
           writeStackTrace()
-          when defined(debug):
-            echo "Internal stacktrace:"
-            let exc = getCurrentException()
+          echo "Internal stacktrace:"
+          let exc = getCurrentException()
+          if not isNil(exc.parent):
             echo getStackTrace(exc.parent)
         except: discard
       echo "[NimYAML] Please report this bug."

--- a/yaml/private/internal.nim
+++ b/yaml/private/internal.nim
@@ -5,16 +5,24 @@
 #    distribution, for details about the copyright.
 
 template internalError*(s: string) =
+  # Note: to get the internal stacktrace that caused the error
+  # compile with the `d:debug` flag.
   when not defined(release):
     let ii = instantiationInfo()
     echo "[NimYAML] Error in file ", ii.filename, " at line ", ii.line, ":"
     echo s
     when not defined(JS):
       echo "[NimYAML] Stacktrace:"
-      try: writeStackTrace()
+      try:
+        writeStackTrace()
+        when defined(debug):
+          echo "Internal stacktrace:"
+          let exc = getCurrentException()
+          echo getStackTrace(exc.parent)
       except: discard
     echo "[NimYAML] Please report this bug."
     quit 1
+
 template yAssert*(e: typed) =
   when not defined(release):
     if not e:
@@ -23,7 +31,12 @@ template yAssert*(e: typed) =
       echo "assertion failed!"
       when not defined(JS):
         echo "[NimYAML] Stacktrace:"
-        try: writeStackTrace()
+        try:
+          writeStackTrace()
+          when defined(debug):
+            echo "Internal stacktrace:"
+            let exc = getCurrentException()
+            echo getStackTrace(exc.parent)
         except: discard
       echo "[NimYAML] Please report this bug."
       quit 1

--- a/yaml/private/internal.nim
+++ b/yaml/private/internal.nim
@@ -15,9 +15,9 @@ template internalError*(s: string) =
       echo "[NimYAML] Stacktrace:"
       try:
         writeStackTrace()
-        echo "Internal stacktrace:"
         let exc = getCurrentException()
         if not isNil(exc.parent):
+          echo "Internal stacktrace:"
           echo getStackTrace(exc.parent)
       except: discard
     echo "[NimYAML] Please report this bug."
@@ -33,9 +33,9 @@ template yAssert*(e: typed) =
         echo "[NimYAML] Stacktrace:"
         try:
           writeStackTrace()
-          echo "Internal stacktrace:"
           let exc = getCurrentException()
           if not isNil(exc.parent):
+            echo "Internal stacktrace:"
             echo getStackTrace(exc.parent)
         except: discard
       echo "[NimYAML] Please report this bug."

--- a/yaml/private/lex.nim
+++ b/yaml/private/lex.nim
@@ -1161,22 +1161,22 @@ when not defined(JS):
 
 proc newYamlLexer*(source: string, startAt: int = 0): YamlLexer
     {.raises: [].} =
+  # append a `\0` at the very end to work around null terminator being
+  # inaccessible
+  let sourceNull = source & '\0'
   when defined(JS):
     let sSource = StringSource(pos: startAt, lineStart: startAt, line: 1,
-        src: source)
+                               src: sourceNull)
     result = YamlLexer(buf: "", sSource: sSource,
         inFlow: false, c: sSource.src[startAt], newlines: 0, folded: true)
   else:
     let sSource = new(StringSource)
     sSource[] = StringSource(pos: startAt, lineStart: startAt, line: 1,
-        src: source)
+                             src: sourceNull)
     GC_ref(sSource)
     new(result, proc(x: ref YamlLexerObj) {.nimcall.} =
         GC_unref(cast[ref StringSource](x.source))
     )
-    # append a `\0` at the very end to work around null terminator being
-    # inaccessible
-    sSource.src.add '\0'
     result[] = YamlLexerObj(buf: "", source: cast[pointer](sSource),
         inFlow: false, c: sSource.src[startAt], newlines: 0, folded: true)
   init[StringSource](result)

--- a/yaml/private/lex.nim
+++ b/yaml/private/lex.nim
@@ -140,10 +140,7 @@ template lexLF(lex: YamlLexer, t: typedesc[StringSource]) =
   lex.sSource.pos.inc()
   lex.sSource.lineStart = lex.sSource.pos
   lex.sSource.line.inc()
-  if lex.sSource.pos < lex.sSource.src.len:
-    lex.c = lex.sSource.src[lex.sSource.pos]
-  else:
-    lex.c = '\0'
+  lex.c = lex.sSource.src[lex.sSource.pos]
 
 template lineNumber(lex: YamlLexer, t: typedesc[BaseLexer]): int =
   lex.blSource.lineNumber
@@ -190,10 +187,7 @@ proc at(lex: YamlLexer, t: typedesc[BaseLexer], pos: int): char {.inline.} =
   lex.blSource.buf[pos]
 
 proc at(lex: YamlLexer, t: typedesc[StringSource], pos: int): char {.inline.} =
-  if lex.sSource.src.len == pos:
-    '\0'
-  else:
-    lex.sSource.src[pos]
+  lex.sSource.src[pos]
 
 proc mark(lex: YamlLexer, t: typedesc[BaseLexer]): int = lex.blSource.bufpos
 proc mark(lex: YamlLexer, t: typedesc[StringSource]): int = lex.sSource.pos
@@ -1180,15 +1174,11 @@ proc newYamlLexer*(source: string, startAt: int = 0): YamlLexer
     new(result, proc(x: ref YamlLexerObj) {.nimcall.} =
         GC_unref(cast[ref StringSource](x.source))
     )
-    var sChar = '\0'
     # append a `\0` at the very end to work around null terminator being
     # inaccessible
-    sSource.src.add sChar
-    if source.len > 0:
-      sChar = sSource.src[startAt]
+    sSource.src.add '\0'
     result[] = YamlLexerObj(buf: "", source: cast[pointer](sSource),
-                            inFlow: false, c: sChar, newlines: 0, folded: true)
-
+        inFlow: false, c: sSource.src[startAt], newlines: 0, folded: true)
   init[StringSource](result)
 
 proc next*(lex: YamlLexer) =

--- a/yaml/private/lex.nim
+++ b/yaml/private/lex.nim
@@ -1181,6 +1181,9 @@ proc newYamlLexer*(source: string, startAt: int = 0): YamlLexer
         GC_unref(cast[ref StringSource](x.source))
     )
     var sChar = '\0'
+    # append a `\0` at the very end to work around null terminator being
+    # inaccessible
+    sSource.src.add sChar
     if source.len > 0:
       sChar = sSource.src[startAt]
     result[] = YamlLexerObj(buf: "", source: cast[pointer](sSource),

--- a/yaml/private/lex.nim
+++ b/yaml/private/lex.nim
@@ -218,31 +218,19 @@ proc lineWithMarker(lex: YamlLexer, pos: tuple[line, column: int],
     lineStartIndex = lex.sSource.pos
     lineEndIndex: int
     curLine = lex.sSource.line
-  let srcHigh = lex.sSource.src.high
   if pos.line == curLine:
     lineEndIndex = lex.sSource.pos
-    if lineEndIndex < srcHigh:
-      while lineEndIndex < srcHigh and
-            lex.sSource.src[lineEndIndex] notin lineEnd:
-        inc(lineEndIndex)
+    while lex.sSource.src[lineEndIndex] notin lineEnd: inc(lineEndIndex)
   while true:
-    while lineStartIndex >= 0 and
-          lineStartIndex < srcHigh and
-          lex.sSource.src[lineStartIndex] notin lineEnd:
+    while lineStartIndex >= 0 and lex.sSource.src[lineStartIndex] notin lineEnd:
       dec(lineStartIndex)
-    if curLine == pos.line and lineStartIndex < srcHigh:
+    if curLine == pos.line:
       inc(lineStartIndex)
       break
-    let wasLF = if lineStartIndex > srcHigh or lineStartIndex < 0: false
-                else: lex.sSource.src[lineStartIndex] == '\l'
+    let wasLF = lex.sSource.src[lineStartIndex] == '\l'
     lineEndIndex = lineStartIndex
-    if lineStartIndex > 0:
-      dec(lineStartIndex)
-    else:
-      break
-    if lineStartIndex > 0 and
-       lineStartIndex <= srcHigh and
-       lex.sSource.src[lineStartIndex] == '\c' and wasLF:
+    dec(lineStartIndex)
+    if lex.sSource.src[lineStartIndex] == '\c' and wasLF:
       dec(lineStartIndex)
       dec(lineEndIndex)
     dec(curLine)

--- a/yaml/private/lex.nim
+++ b/yaml/private/lex.nim
@@ -29,7 +29,7 @@ type
     curStartPos*: tuple[line, column: int]
     # ltScalarPart, ltQuotedScalar, ltYamlVersion, ltTagShorthand, ltTagUri,
     # ltLiteralTag, ltTagHandle, ltAnchor, ltAlias
-    buf*: string not nil
+    buf*: string
     # ltIndentation
     indentation*: int
     # ltTagHandle

--- a/yaml/serialization.nim
+++ b/yaml/serialization.nim
@@ -1154,10 +1154,6 @@ proc constructChild*(s: var YamlStream, c: ConstructionContext,
                      result: var string) =
   let item = s.peek()
   if item.kind == yamlScalar:
-    #if item.scalarTag == yTagNimNilString:
-    #  discard s.next()
-    #  result = ""
-    #  return
     if item.scalarTag notin
         [yTagQuestionMark, yTagExclamationMark, yamlTag(string)]:
       raise s.constructionError("Wrong tag for string")
@@ -1238,8 +1234,6 @@ proc constructChild*[O](s: var YamlStream, c: ConstructionContext,
     raise e
 
 proc representChild*(value: string, ts: TagStyle, c: SerializationContext) =
-  #if value.len == 0: c.put(scalarEvent("", yTagNimNilString))
-  #else:
   let tag = presentTag(string, ts)
   representObject(value, ts, c,
                   if tag == yTagQuestionMark and guessType(value) != yTypeUnknown:
@@ -1248,8 +1242,6 @@ proc representChild*(value: string, ts: TagStyle, c: SerializationContext) =
                     tag)
 
 proc representChild*[T](value: seq[T], ts: TagStyle, c: SerializationContext) =
-  #if value.len == 0: c.put(scalarEvent("", yTagNimNilSeq))
-  #else:
   representObject(value, ts, c, presentTag(seq[T], ts))
 
 proc representChild*[O](value: ref O, ts: TagStyle, c: SerializationContext) =

--- a/yaml/serialization.nim
+++ b/yaml/serialization.nim
@@ -204,8 +204,8 @@ proc constructObject*[T: int8|int16|int32|int64](
         # make sure we don't produce a range error
         result = T(nInt)
       else:
-        # if outside of range, what to do?!
-        raise newException(YamlConstructionError, "AAA")
+        raise s.constructionError("Cannot construct int; out of range: " &
+          $nInt & " for type " & T.name & " with max of: " & $T.high)
 
 proc constructObject*(s: var YamlStream, c: ConstructionContext,
                       result: var int)

--- a/yaml/serialization.nim
+++ b/yaml/serialization.nim
@@ -1351,8 +1351,6 @@ proc load*[K](input: Stream | string, target: var K)
     else: internalError("Unexpected exception: " & $e.parent.name)
 
 proc loadMultiDoc*[K](input: Stream | string, target: var seq[K]) =
-  if target.len == 0:
-    target = newSeq[K]()
   var
     parser = newYamlParser(serializationTagLibrary)
     events = parser.parse(input)

--- a/yaml/serialization.nim
+++ b/yaml/serialization.nim
@@ -199,7 +199,13 @@ proc constructObject*[T: int8|int16|int32|int64](
     elif item.scalarContent[0] == '0' and item.scalarContent.len > 1 and item.scalarContent[1] in {'o', 'O'}:
       result = parseOctal[T](s, item.scalarContent)
     else:
-      result = T(parseBiggestInt(item.scalarContent))
+      let nInt = parseBiggestInt(item.scalarContent)
+      if nInt <= T.high:
+        # make sure we don't produce a range error
+        result = T(nInt)
+      else:
+        # if outside of range, what to do?!
+        raise newException(YamlConstructionError, "AAA")
 
 proc constructObject*(s: var YamlStream, c: ConstructionContext,
                       result: var int)

--- a/yaml/serialization.nim
+++ b/yaml/serialization.nim
@@ -1148,11 +1148,11 @@ proc constructChild*(s: var YamlStream, c: ConstructionContext,
                      result: var string) =
   let item = s.peek()
   if item.kind == yamlScalar:
-    if item.scalarTag == yTagNimNilString:
-      discard s.next()
-      result = ""
-      return
-    elif item.scalarTag notin
+    #if item.scalarTag == yTagNimNilString:
+    #  discard s.next()
+    #  result = ""
+    #  return
+    if item.scalarTag notin
         [yTagQuestionMark, yTagExclamationMark, yamlTag(string)]:
       raise s.constructionError("Wrong tag for string")
     elif item.scalarAnchor != yAnchorNone:
@@ -1163,10 +1163,11 @@ proc constructChild*[T](s: var YamlStream, c: ConstructionContext,
                         result: var seq[T]) =
   let item = s.peek()
   if item.kind == yamlScalar:
-    if item.scalarTag == yTagNimNilSeq:
-      discard s.next()
-      result = @[]
-      return
+    #if item.scalarTag == yTagNimNilSeq:
+    # TODO: this whole branch still makes sense
+    discard s.next()
+    result = @[]
+    return
   elif item.kind == yamlStartSeq:
     if item.seqTag notin [yTagQuestionMark, yamlTag(seq[T])]:
       raise s.constructionError("Wrong tag for " & typetraits.name(seq[T]))
@@ -1231,16 +1232,19 @@ proc constructChild*[O](s: var YamlStream, c: ConstructionContext,
     raise e
 
 proc representChild*(value: string, ts: TagStyle, c: SerializationContext) =
-  if value.len == 0: c.put(scalarEvent("", yTagNimNilString))
-  else:
-    let tag = presentTag(string, ts)
-    representObject(value, ts, c,
-        if tag == yTagQuestionMark and guessType(value) != yTypeUnknown:
-          yTagExclamationMark else: tag)
+  #if value.len == 0: c.put(scalarEvent("", yTagNimNilString))
+  #else:
+  let tag = presentTag(string, ts)
+  representObject(value, ts, c,
+                  if tag == yTagQuestionMark and guessType(value) != yTypeUnknown:
+                    yTagExclamationMark
+                  else:
+                    tag)
 
 proc representChild*[T](value: seq[T], ts: TagStyle, c: SerializationContext) =
-  if value.len == 0: c.put(scalarEvent("", yTagNimNilSeq))
-  else: representObject(value, ts, c, presentTag(seq[T], ts))
+  #if value.len == 0: c.put(scalarEvent("", yTagNimNilSeq))
+  #else:
+  representObject(value, ts, c, presentTag(seq[T], ts))
 
 proc representChild*[O](value: ref O, ts: TagStyle, c: SerializationContext) =
   if isNil(value): c.put(scalarEvent("~", yTagNull))

--- a/yaml/serialization.nim
+++ b/yaml/serialization.nim
@@ -985,11 +985,11 @@ macro genRepresentObject(t: typedesc, value, childTagStyle: typed): typed =
         childAccessor = newDotExpr(value, newIdentNode(name))
       result.add(quote do:
         when `tSym` == -1 or `fieldIndex` notin transientVectors[`tSym`]:
-          when `isVO`: c.put(startMapEvent(yTagQuestionMark, yAnchorNone))
+          when bool(`isVO`): c.put(startMapEvent(yTagQuestionMark, yAnchorNone))
           c.put(scalarEvent(`name`, if `childTagStyle` == tsNone:
               yTagQuestionMark else: yTagNimField, yAnchorNone))
           representChild(`childAccessor`, `childTagStyle`, c)
-          when `isVO`: c.put(endMapEvent())
+          when bool(`isVO`): c.put(endMapEvent())
       )
     inc(fieldIndex)
 

--- a/yaml/serialization.nim
+++ b/yaml/serialization.nim
@@ -1349,7 +1349,7 @@ proc load*[K](input: Stream | string, target: var K)
     else: internalError("Unexpected exception: " & $e.parent.name)
 
 proc loadMultiDoc*[K](input: Stream | string, target: var seq[K]) =
-  if target.isNil:
+  if target.len == 0:
     target = newSeq[K]()
   var
     parser = newYamlParser(serializationTagLibrary)

--- a/yaml/serialization.nim
+++ b/yaml/serialization.nim
@@ -1164,13 +1164,7 @@ proc constructChild*(s: var YamlStream, c: ConstructionContext,
 proc constructChild*[T](s: var YamlStream, c: ConstructionContext,
                         result: var seq[T]) =
   let item = s.peek()
-  if item.kind == yamlScalar:
-    #if item.scalarTag == yTagNimNilSeq:
-    # TODO: this whole branch still makes sense
-    discard s.next()
-    result = @[]
-    return
-  elif item.kind == yamlStartSeq:
+  if item.kind == yamlStartSeq:
     if item.seqTag notin [yTagQuestionMark, yamlTag(seq[T])]:
       raise s.constructionError("Wrong tag for " & typetraits.name(seq[T]))
     elif item.seqAnchor != yAnchorNone:

--- a/yaml/serialization.nim
+++ b/yaml/serialization.nim
@@ -390,7 +390,7 @@ proc constructObject*(s: var YamlStream, c: ConstructionContext,
             tmp.add(item.scalarContent[pos + 1])
           else:
             tmp.add(item.scalarContent[pos .. pos + 2])
-      let info = tmp.parse("yyyy-M-d'T'H-mm-sszzz")
+      let info = tmp.parse("yyyy-M-d'T'H:mm:sszzz")
       result = info.toTime()
     else:
       raise s.constructionError("Not a parsable timestamp: " &

--- a/yaml/serialization.nim
+++ b/yaml/serialization.nim
@@ -672,7 +672,7 @@ proc markAsFound(i: int, matched: NimNode): NimNode {.compileTime.} =
       newLit(true))
 
 proc ifNotTransient(tSym: NimNode, fieldIndex: int, content: openarray[NimNode],
-    elseError: bool = false, s: NimNode = nil, tName, fName: string = nil):
+    elseError: bool = false, s: NimNode = nil, tName, fName: string = ""):
     NimNode {.compileTime.} =
   var stmts = newStmtList(content)
   result = quote do:
@@ -1150,7 +1150,7 @@ proc constructChild*(s: var YamlStream, c: ConstructionContext,
   if item.kind == yamlScalar:
     if item.scalarTag == yTagNimNilString:
       discard s.next()
-      result = nil
+      result = ""
       return
     elif item.scalarTag notin
         [yTagQuestionMark, yTagExclamationMark, yamlTag(string)]:
@@ -1165,7 +1165,7 @@ proc constructChild*[T](s: var YamlStream, c: ConstructionContext,
   if item.kind == yamlScalar:
     if item.scalarTag == yTagNimNilSeq:
       discard s.next()
-      result = nil
+      result = @[]
       return
   elif item.kind == yamlStartSeq:
     if item.seqTag notin [yTagQuestionMark, yamlTag(seq[T])]:
@@ -1231,7 +1231,7 @@ proc constructChild*[O](s: var YamlStream, c: ConstructionContext,
     raise e
 
 proc representChild*(value: string, ts: TagStyle, c: SerializationContext) =
-  if isNil(value): c.put(scalarEvent("", yTagNimNilString))
+  if value.len == 0: c.put(scalarEvent("", yTagNimNilString))
   else:
     let tag = presentTag(string, ts)
     representObject(value, ts, c,
@@ -1239,7 +1239,7 @@ proc representChild*(value: string, ts: TagStyle, c: SerializationContext) =
           yTagExclamationMark else: tag)
 
 proc representChild*[T](value: seq[T], ts: TagStyle, c: SerializationContext) =
-  if isNil(value): c.put(scalarEvent("", yTagNimNilSeq))
+  if value.len == 0: c.put(scalarEvent("", yTagNimNilSeq))
   else: representObject(value, ts, c, presentTag(seq[T], ts))
 
 proc representChild*[O](value: ref O, ts: TagStyle, c: SerializationContext) =

--- a/yaml/stream.nim
+++ b/yaml/stream.nim
@@ -140,7 +140,7 @@ when not defined(JS):
 type
   BufferYamlStream* = ref object of YamlStream
     pos: int
-    buf: seq[YamlStreamEvent] not nil
+    buf: seq[YamlStreamEvent]
 
 proc newBufferYamlStream*(): BufferYamlStream not nil =
   result = cast[BufferYamlStream not nil](new(BufferYamlStream))

--- a/yaml/taglib.nim
+++ b/yaml/taglib.nim
@@ -89,10 +89,10 @@ const
     ## This tag is used in serialization for the name of a field of an
     ## object. It may contain any string scalar that is a valid Nim symbol.
 
-  yTagNimNilString* : TagId = 101.TagId ## for strings that are nil
-  yTagNimNilSeq*    : TagId = 102.TagId ## \
-    ## for seqs that are nil. This tag is used regardless of the seq's generic
-    ## type parameter.
+  #yTagNimNilString* : TagId = 101.TagId ## for strings that are nil
+  #yTagNimNilSeq*    : TagId = 102.TagId ## \
+  ## for seqs that are nil. This tag is used regardless of the seq's generic
+  ## type parameter.
 
   yFirstStaticTagId* : TagId = 1000.TagId ## \
     ## The first ``TagId`` assigned by the ``setTagId`` templates.
@@ -211,8 +211,8 @@ proc initSerializationTagLibrary*(): TagLibrary =
   result.tags[y"value"]      = yTagValue
   result.tags[y"binary"]     = yTagBinary
   result.tags[n"field"]      = yTagNimField
-  result.tags[n"nil:string"] = yTagNimNilString
-  result.tags[n"nil:seq"]    = yTagNimNilSeq
+  #result.tags[n"nil:string"] = yTagNimNilString
+  #result.tags[n"nil:seq"]    = yTagNimNilSeq
 
 var
   serializationTagLibrary* = initSerializationTagLibrary() ## \
@@ -275,8 +275,8 @@ static:
   registeredUris.add(y"binary")
   # special tags used by serialization
   registeredUris.add(n"field")
-  registeredUris.add(n"nil:string")
-  registeredUris.add(n"nil:seq")
+  #registeredUris.add(n"nil:string")
+  #registeredUris.add(n"nil:seq")
 
 # tags for Nim's standard types
 setTagUri(char, n"system:char", yTagNimChar)

--- a/yaml/taglib.nim
+++ b/yaml/taglib.nim
@@ -89,11 +89,6 @@ const
     ## This tag is used in serialization for the name of a field of an
     ## object. It may contain any string scalar that is a valid Nim symbol.
 
-  #yTagNimNilString* : TagId = 101.TagId ## for strings that are nil
-  #yTagNimNilSeq*    : TagId = 102.TagId ## \
-  ## for seqs that are nil. This tag is used regardless of the seq's generic
-  ## type parameter.
-
   yFirstStaticTagId* : TagId = 1000.TagId ## \
     ## The first ``TagId`` assigned by the ``setTagId`` templates.
 
@@ -211,8 +206,6 @@ proc initSerializationTagLibrary*(): TagLibrary =
   result.tags[y"value"]      = yTagValue
   result.tags[y"binary"]     = yTagBinary
   result.tags[n"field"]      = yTagNimField
-  #result.tags[n"nil:string"] = yTagNimNilString
-  #result.tags[n"nil:seq"]    = yTagNimNilSeq
 
 var
   serializationTagLibrary* = initSerializationTagLibrary() ## \
@@ -275,8 +268,6 @@ static:
   registeredUris.add(y"binary")
   # special tags used by serialization
   registeredUris.add(n"field")
-  #registeredUris.add(n"nil:string")
-  #registeredUris.add(n"nil:seq")
 
 # tags for Nim's standard types
 setTagUri(char, n"system:char", yTagNimChar)

--- a/yaml/tojson.nim
+++ b/yaml/tojson.nim
@@ -116,7 +116,7 @@ proc constructJson*(s: var YamlStream): seq[JsonNode]
       if levels.len == 0:
         # parser ensures that next event will be yamlEndDocument
         levels.add((node: jsonFromScalar(event.scalarContent,
-                                         event.scalarTag), key: nil))
+                                         event.scalarTag), key: ""))
         continue
 
       case levels[levels.high].node.kind
@@ -127,7 +127,7 @@ proc constructJson*(s: var YamlStream): seq[JsonNode]
         if event.scalarAnchor != yAnchorNone:
           anchors[event.scalarAnchor] = jsonScalar
       of JObject:
-        if isNil(levels[levels.high].key):
+        if levels[levels.high].key.len == 0:
           # JSON only allows strings as keys
           levels[levels.high].key = event.scalarContent
           if event.scalarAnchor != yAnchorNone:
@@ -137,7 +137,7 @@ proc constructJson*(s: var YamlStream): seq[JsonNode]
           let jsonScalar = jsonFromScalar(event.scalarContent,
                                           event.scalarTag)
           levels[levels.high].node[levels[levels.high].key] = jsonScalar
-          levels[levels.high].key = nil
+          levels[levels.high].key = ""
           if event.scalarAnchor != yAnchorNone:
             anchors[event.scalarAnchor] = jsonScalar
       else:
@@ -148,12 +148,12 @@ proc constructJson*(s: var YamlStream): seq[JsonNode]
         case levels[levels.high].node.kind
         of JArray: levels[levels.high].node.elems.add(level.node)
         of JObject:
-          if isNil(levels[levels.high].key):
+          if levels[levels.high].key.len == 0:
             raise newException(YamlConstructionError,
                 "non-scalar as key not allowed in JSON")
           else:
             levels[levels.high].node[levels[levels.high].key] = level.node
-            levels[levels.high].key = nil
+            levels[levels.high].key = ""
         else:
           internalError("Unexpected node kind: " &
                         $levels[levels.high].node.kind)
@@ -166,13 +166,13 @@ proc constructJson*(s: var YamlStream): seq[JsonNode]
         levels[levels.high].node.elems.add(
             anchors.getOrDefault(event.aliasTarget))
       of JObject:
-        if isNil(levels[levels.high].key):
+        if levels[levels.high].key.len == 0:
           raise newException(YamlConstructionError,
               "cannot use alias node as key in JSON")
         else:
           levels[levels.high].node.fields.add(
               levels[levels.high].key, anchors.getOrDefault(event.aliasTarget))
-          levels[levels.high].key = nil
+          levels[levels.high].key = ""
       else:
         internalError("Unexpected node kind: " & $levels[levels.high].node.kind)
 


### PR DESCRIPTION
First of all, this PR is based on @alehander42 PR to fix the `nil` strings.

Besides this, there's been several changes which also cause regressions in the test cases. From the top of my head:
- null terminator in strings not accessible anymore
- compile time behavior of `when` expressions is forced a bool, but `quote do` returns an int

And as it seems converting an integer, which doesn't fit into some int type throws a different error? The case that tries it fails, so I hacked that.

With these changes the test suite works up to `Load tuple - missing field`. There it  still crashes. I'll try to see what's going on there/

Maybe (some) of the changes I made are stupid ways to handle the stuff? Quite possibly, since I don't know the code base. The hardest part for me is the internal exception handling, since I can't see where the ACTUAL exception is being raised, since it's replaced by the "user focused" stack trace, which simply points to the YAML call in the *user* file and a note "please report the bug".