### PR TITLE
Change serialization to omit `none(T)` fields of sparse objects

### DIFF
--- a/yaml/annotations.nim
+++ b/yaml/annotations.nim
@@ -27,7 +27,8 @@ template sparse*() {.pragma.}
   ## This annotation can be put on an object type. During deserialization,
   ## the input may omit any field that has an ``Option[T]`` type (for any
   ## concrete ``T``) and that field will be treated as if it had the annotation
-  ## ``{.defaultVal: none(T).}``.
+  ## ``{.defaultVal: none(T).}``. Fields of ``none(T)`` value are omitted
+  ## during serialization.
   ##
   ## Example usage:
   ##

--- a/yaml/serialization.nim
+++ b/yaml/serialization.nim
@@ -967,18 +967,17 @@ macro genRepresentObject(t: typedesc, value, childTagStyle: typed) =
         name = $child
         childAccessor = newDotExpr(value, newIdentNode(name))
       result.add(quote do:
-        template representChild =
+        template serializeImpl =
           when bool(`isVO`): c.put(startMapEvent())
           c.put(scalarEvent(`name`, if `childTagStyle` == tsNone:
               yTagQuestionMark else: yTagNimField, yAnchorNone))
           representChild(`childAccessor`, `childTagStyle`, c)
           when bool(`isVO`): c.put(endMapEvent())
         when not `childAccessor`.hasCustomPragma(transient):
-          when not hasSparse(`t`) or (hasSparse(`t`) and `child` is not Option):
-            representChild()
-          elif hasSparse(`t`) and `child` is Option:
-            if `childAccessor`.isSome:
-              representChild()
+          when hasSparse(`t`) and `child` is Option:
+            if `childAccessor`.isSome: serializeImpl()
+          else:
+            serializeImpl()
       )
     inc(fieldIndex)
 


### PR DESCRIPTION
I did this because I wanted a clean dump without all those nasty `!!null ~`'s that made my eyes weep. Let me know if this a no no, utter crap, or if should be behind a flag.

By the way, thank you very much for this excellent library. I use it all the time.