### PR TITLE
replace shallowCopy for ARC/ORC

### DIFF
--- a/yaml/stream.nim
+++ b/yaml/stream.nim
@@ -105,14 +105,14 @@ proc next*(s: YamlStream): Event {.raises: [YamlStreamError], gcSafe.} =
       e.parent = cur
       raise e
 
-proc peek*(s: YamlStream): Event {.raises: [YamlStreamError].} =
+proc peek*(s: YamlStream): lent Event {.raises: [YamlStreamError].} =
   ## Get the next item of the stream without advancing the stream.
   ## Requires ``finished(s) == true``. Handles exceptions of the backend like
   ## ``next()``.
   if not s.peeked:
     s.cached = s.next()
     s.peeked = true
-  shallowCopy(result, s.cached)
+  result = s.cached
 
 proc `peek=`*(s: YamlStream, value: Event) {.raises: [].} =
   ## Set the next item of the stream. Will replace a previously peeked item,

--- a/yaml/tojson.nim
+++ b/yaml/tojson.nim
@@ -21,7 +21,7 @@ type Level = tuple[node: JsonNode, key: string, expKey: bool]
 proc initLevel(node: JsonNode): Level {.raises: [].} =
   (node: node, key: "", expKey: true)
 
-proc jsonFromScalar(content: string, tag: Tag): JsonNode
+proc jsonFromScalar(content: sink string, tag: Tag): JsonNode
    {.raises: [YamlConstructionError].}=
   new(result)
   var mappedType: TypeHint
@@ -66,7 +66,10 @@ proc jsonFromScalar(content: string, tag: Tag): JsonNode
       result = JsonNode(kind: JNull)
     else:
       result = JsonNode(kind: JString)
-      shallowCopy(result.str, content)
+      when defined(gcArc) or defined(gcOrc):
+        result.str = content
+      else:
+        shallowCopy(result.str, content)
   except ValueError:
     var e = newException(YamlConstructionError, "Cannot parse numeric value")
     e.parent = getCurrentException()


### PR DESCRIPTION
`shallowCopy` has already been removed for ARC/ORC on the devel branch. The PR is my best effort to replace `shallowCopy` with similar functionality code.

Ref https://github.com/nim-lang/Nim/pull/19972