### PR TITLE
Adapt type hinting to Yaml 1.2.2

### DIFF
--- a/config.nims
+++ b/config.nims
@@ -38,6 +38,11 @@ task quickstartTests, "Run quickstart tests":
   --verbosity:0
   setCommand "c", "test/tquickstart"
 
+task hintsTests, "Run hints tests":
+  --r
+  --verbosity:0
+  setCommand "c", "test/thints"
+
 task documentation, "Generate documentation":
   exec "mkdir -p docout"
   withDir "doc":

--- a/test/tests.nim
+++ b/test/tests.nim
@@ -5,7 +5,7 @@
 #    distribution, for details about the copyright.
 
 {.warning[UnusedImport]: off.}
-import tlex, tjson, tserialization, tparser, tquickstart, tannotations
+import tlex, tjson, tserialization, tparser, tquickstart, tannotations, thints
 
 when not defined(gcArc) or defined(gcOrc):
   import tdom

--- a/test/thints.nim
+++ b/test/thints.nim
@@ -2,7 +2,7 @@ import unittest
 import ../yaml/hints
 
 suite "Hints":
-  test "Integers":
+  test "Int":
     # [-+]? [0-9]+
     assert guessType("0") == yTypeInteger
     assert guessType("01") == yTypeInteger
@@ -11,7 +11,15 @@ suite "Hints":
     assert guessType("-4248") == yTypeInteger
     assert guessType("+4248") == yTypeInteger
 
-  test "Floats":
+  test "Non-Int":
+    assert guessType("0+0") != yTypeInteger
+    assert guessType("0-1") != yTypeInteger
+    assert guessType("1x0") != yTypeInteger
+    assert guessType("248e") != yTypeInteger
+    assert guessType("-4248 4") != yTypeInteger
+    assert guessType("+-4248") != yTypeInteger
+
+  test "Float":
     # [-+]? ( \. [0-9]+ | [0-9]+ ( \. [0-9]* )? ) ( [eE] [-+]? [0-9]+ )?
 
     # Batch: [-+]? ( \. [0-9]+ | [0-9]+ ( \. [0-9]* )? )
@@ -151,7 +159,7 @@ suite "Hints":
     assert guessType("+05e-05") == yTypeFloat
     assert guessType("-05e-05") == yTypeFloat
 
-  test "Non-Floats":
+  test "Non-Float":
     assert guessType(".") != yTypeFloat
     assert guessType("+.") != yTypeFloat
     assert guessType("-.") != yTypeFloat
@@ -160,27 +168,85 @@ suite "Hints":
     assert guessType("-.e4") != yTypeFloat
 
   test "Bool-True":
-    assert guessType("y") == yTypeBoolTrue
-    assert guessType("Y") == yTypeBoolTrue
-    assert guessType("yes") == yTypeBoolTrue
-    assert guessType("Yes") == yTypeBoolTrue
+    # ``true | True | TRUE``
     assert guessType("true") == yTypeBoolTrue
     assert guessType("True") == yTypeBoolTrue
-    assert guessType("on") == yTypeBoolTrue
-    assert guessType("On") == yTypeBoolTrue
+    assert guessType("TRUE") == yTypeBoolTrue
 
   test "Bool-False":
-    assert guessType("n") == yTypeBoolFalse
-    assert guessType("N") == yTypeBoolFalse
-    assert guessType("no") == yTypeBoolFalse
-    assert guessType("No") == yTypeBoolFalse
+    # ``false | False | FALSE``
     assert guessType("false") == yTypeBoolFalse
     assert guessType("False") == yTypeBoolFalse
-    assert guessType("off") == yTypeBoolFalse
-    assert guessType("Off") == yTypeBoolFalse
+    assert guessType("FALSE") == yTypeBoolFalse
 
-  test "Non-Bools":
-    assert guessType("ye") != yTypeBoolTrue
-    assert guessType("yse") != yTypeBoolTrue
-    # assert guessType("nO") != yTypeBoolFalse
-    assert guessType("flase") != yTypeBoolFalse
+  test "Non-Bool":
+    # y, yes, on should not be treated as bool
+    assert guessType("y") notin {yTypeBoolTrue, yTypeBoolFalse}
+    assert guessType("Y") notin {yTypeBoolTrue, yTypeBoolFalse}
+    assert guessType("yes") notin {yTypeBoolTrue, yTypeBoolFalse}
+    assert guessType("Yes") notin {yTypeBoolTrue, yTypeBoolFalse}
+    assert guessType("on") notin {yTypeBoolTrue, yTypeBoolFalse}
+    assert guessType("On") notin {yTypeBoolTrue, yTypeBoolFalse}
+
+    # n, no, off should not be treated as bool
+    assert guessType("n") notin {yTypeBoolFalse, yTypeBoolFalse}
+    assert guessType("N") notin {yTypeBoolFalse, yTypeBoolFalse}
+    assert guessType("no") notin {yTypeBoolFalse, yTypeBoolFalse}
+    assert guessType("No") notin {yTypeBoolFalse, yTypeBoolFalse}
+    assert guessType("off") notin {yTypeBoolFalse, yTypeBoolFalse}
+    assert guessType("Off") notin {yTypeBoolFalse, yTypeBoolFalse}
+
+    # miss-cased words should not be treated as bool
+    assert guessType("tRUE") notin {yTypeBoolTrue, yTypeBoolFalse}
+    assert guessType("TRue") notin {yTypeBoolTrue, yTypeBoolFalse}
+    assert guessType("fAlse") notin {yTypeBoolTrue, yTypeBoolFalse}
+    assert guessType("FALSe") notin {yTypeBoolTrue, yTypeBoolFalse}
+
+    # miss-spelled words should not be treated as bool
+    assert guessType("ye") notin {yTypeBoolTrue, yTypeBoolFalse}
+    assert guessType("yse") notin {yTypeBoolTrue, yTypeBoolFalse}
+    assert guessType("nO") notin {yTypeBoolTrue, yTypeBoolFalse}
+    assert guessType("flase") notin {yTypeBoolTrue, yTypeBoolFalse}
+
+  test "Inf":
+    # ``[-+]? ( \.inf | \.Inf | \.INF )``
+    assert guessType(".inf") == yTypeFloatInf
+    assert guessType(".Inf") == yTypeFloatInf
+    assert guessType(".INF") == yTypeFloatInf
+
+    assert guessType("+.inf") == yTypeFloatInf
+    assert guessType("+.Inf") == yTypeFloatInf
+    assert guessType("+.INF") == yTypeFloatInf
+
+    assert guessType("-.inf") == yTypeFloatInf
+    assert guessType("-.Inf") == yTypeFloatInf
+    assert guessType("-.INF") == yTypeFloatInf
+
+  test "Non-Inf":
+    assert guessType(".InF") != yTypeFloatInf
+    assert guessType(".INf") != yTypeFloatInf
+
+  test "NaN":
+    # ``\.nan | \.NaN | \.NAN``
+    assert guessType(".nan") == yTypeFloatNaN
+    assert guessType(".NaN") == yTypeFloatNaN
+    assert guessType(".NAN") == yTypeFloatNaN
+
+  test "Non-NaN":
+    assert guessType(".nAn") != yTypeFloatNaN
+    assert guessType(".Nan") != yTypeFloatNaN
+    assert guessType(".nAN") != yTypeFloatNaN
+
+  test "Null":
+    # ``null | Null | NULL | ~``
+    assert guessType("null") == yTypeNull
+    assert guessType("Null") == yTypeNull
+    assert guessType("NULL") == yTypeNull
+    assert guessType("~") == yTypeNull
+
+  test "Non-Null":
+    assert guessType("NuLL") != yTypeNull
+    assert guessType("NUll") != yTypeNull
+    assert guessType("NULl") != yTypeNull
+    assert guessType("nULL") != yTypeNull
+    assert guessType("~~") != yTypeNull

--- a/test/thints.nim
+++ b/test/thints.nim
@@ -9,7 +9,7 @@ suite "Hints":
     assert guessType("10") == yTypeInteger
     assert guessType("248") == yTypeInteger
     assert guessType("-4248") == yTypeInteger
-    assert guessType("+4248") == yTypeInteger
+    assert guessType("+42489") == yTypeInteger
 
   test "Non-Int":
     assert guessType("0+0") != yTypeInteger
@@ -225,6 +225,9 @@ suite "Hints":
   test "Non-Inf":
     assert guessType(".InF") != yTypeFloatInf
     assert guessType(".INf") != yTypeFloatInf
+    assert guessType("inf") != yTypeFloatInf
+    assert guessType("Inf") != yTypeFloatInf
+    assert guessType("INF") != yTypeFloatInf
 
   test "NaN":
     # ``\.nan | \.NaN | \.NAN``
@@ -236,6 +239,9 @@ suite "Hints":
     assert guessType(".nAn") != yTypeFloatNaN
     assert guessType(".Nan") != yTypeFloatNaN
     assert guessType(".nAN") != yTypeFloatNaN
+    assert guessType("nan") != yTypeFloatNaN
+    assert guessType("NaN") != yTypeFloatNaN
+    assert guessType("NAN") != yTypeFloatNaN
 
   test "Null":
     # ``null | Null | NULL | ~``
@@ -250,3 +256,7 @@ suite "Hints":
     assert guessType("NULl") != yTypeNull
     assert guessType("nULL") != yTypeNull
     assert guessType("~~") != yTypeNull
+    assert guessType(".null") != yTypeNull
+    assert guessType(".Null") != yTypeNull
+    assert guessType(".NULL") != yTypeNull
+    assert guessType(".~") != yTypeNull

--- a/test/thints.nim
+++ b/test/thints.nim
@@ -1,0 +1,186 @@
+import unittest
+import ../yaml/hints
+
+suite "Hints":
+  test "Integers":
+    # [-+]? [0-9]+
+    assert guessType("0") == yTypeInteger
+    assert guessType("01") == yTypeInteger
+    assert guessType("10") == yTypeInteger
+    assert guessType("248") == yTypeInteger
+    assert guessType("-4248") == yTypeInteger
+    assert guessType("+4248") == yTypeInteger
+
+  test "Floats":
+    # [-+]? ( \. [0-9]+ | [0-9]+ ( \. [0-9]* )? ) ( [eE] [-+]? [0-9]+ )?
+
+    # Batch: [-+]? ( \. [0-9]+ | [0-9]+ ( \. [0-9]* )? )
+    assert guessType(".5") == yTypeFloat
+    assert guessType("+.5") == yTypeFloat
+    assert guessType("-.5") == yTypeFloat
+    assert guessType("0.5") == yTypeFloat
+    assert guessType("+0.5") == yTypeFloat
+    assert guessType("-0.5") == yTypeFloat
+    assert guessType("5.5") == yTypeFloat
+    assert guessType("+5.5") == yTypeFloat
+    assert guessType("-5.5") == yTypeFloat
+    assert guessType("5.") == yTypeFloat
+    assert guessType("+5.") == yTypeFloat
+    assert guessType("-5.") == yTypeFloat
+
+    # Batch: [-+]? \. [0-9]+ [eE] [-+]? [0-9]+
+    assert guessType(".5e5") == yTypeFloat
+    assert guessType("+.5e5") == yTypeFloat
+    assert guessType("-.5e5") == yTypeFloat
+    assert guessType(".5e+5") == yTypeFloat
+    assert guessType("+.5e+5") == yTypeFloat
+    assert guessType("-.5e+5") == yTypeFloat
+    assert guessType(".5e-5") == yTypeFloat
+    assert guessType("+.5e-5") == yTypeFloat
+    assert guessType("-.5e-5") == yTypeFloat
+
+    assert guessType(".5e05") == yTypeFloat
+    assert guessType("+.5e05") == yTypeFloat
+    assert guessType("-.5e05") == yTypeFloat
+    assert guessType(".5e+05") == yTypeFloat
+    assert guessType("+.5e+05") == yTypeFloat
+    assert guessType("-.5e+05") == yTypeFloat
+    assert guessType(".5e-05") == yTypeFloat
+    assert guessType("+.5e-05") == yTypeFloat
+    assert guessType("-.5e-05") == yTypeFloat
+
+    assert guessType(".05e5") == yTypeFloat
+    assert guessType("+.05e5") == yTypeFloat
+    assert guessType("-.05e5") == yTypeFloat
+    assert guessType(".05e+5") == yTypeFloat
+    assert guessType("+.05e+5") == yTypeFloat
+    assert guessType("-.05e+5") == yTypeFloat
+    assert guessType(".05e-5") == yTypeFloat
+    assert guessType("+.05e-5") == yTypeFloat
+    assert guessType("-.05e-5") == yTypeFloat
+
+    assert guessType(".05e05") == yTypeFloat
+    assert guessType("+.05e05") == yTypeFloat
+    assert guessType("-.05e05") == yTypeFloat
+    assert guessType(".05e+05") == yTypeFloat
+    assert guessType("+.05e+05") == yTypeFloat
+    assert guessType("-.05e+05") == yTypeFloat
+    assert guessType(".05e-05") == yTypeFloat
+    assert guessType("+.05e-05") == yTypeFloat
+    assert guessType("-.05e-05") == yTypeFloat
+
+    # Batch: [-+]? [0-9]+ \. [0-9]* [eE] [-+]? [0-9]+
+    assert guessType("0.5e5") == yTypeFloat
+    assert guessType("+0.5e5") == yTypeFloat
+    assert guessType("-0.5e5") == yTypeFloat
+    assert guessType("0.5e+5") == yTypeFloat
+    assert guessType("+0.5e+5") == yTypeFloat
+    assert guessType("-0.5e+5") == yTypeFloat
+    assert guessType("0.5e-5") == yTypeFloat
+    assert guessType("+0.5e-5") == yTypeFloat
+    assert guessType("-0.5e-5") == yTypeFloat
+
+    assert guessType("0.5e05") == yTypeFloat
+    assert guessType("+0.5e05") == yTypeFloat
+    assert guessType("-0.5e05") == yTypeFloat
+    assert guessType("0.5e+05") == yTypeFloat
+    assert guessType("+0.5e+05") == yTypeFloat
+    assert guessType("-0.5e+05") == yTypeFloat
+    assert guessType("0.5e-05") == yTypeFloat
+    assert guessType("+0.5e-05") == yTypeFloat
+    assert guessType("-0.5e-05") == yTypeFloat
+
+    assert guessType("0.05e5") == yTypeFloat
+    assert guessType("+0.05e5") == yTypeFloat
+    assert guessType("-0.05e5") == yTypeFloat
+    assert guessType("0.05e+5") == yTypeFloat
+    assert guessType("+0.05e+5") == yTypeFloat
+    assert guessType("-0.05e+5") == yTypeFloat
+    assert guessType("0.05e-5") == yTypeFloat
+    assert guessType("+0.05e-5") == yTypeFloat
+    assert guessType("-0.05e-5") == yTypeFloat
+
+    assert guessType("0.05e05") == yTypeFloat
+    assert guessType("+0.05e05") == yTypeFloat
+    assert guessType("-0.05e05") == yTypeFloat
+    assert guessType("0.05e+05") == yTypeFloat
+    assert guessType("+0.05e+05") == yTypeFloat
+    assert guessType("-0.05e+05") == yTypeFloat
+    assert guessType("0.05e-05") == yTypeFloat
+    assert guessType("+0.05e-05") == yTypeFloat
+    assert guessType("-0.05e-05") == yTypeFloat
+
+    # Batch: [-+]? [0-9]+ [eE] [-+]? [0-9]+
+    assert guessType("5e5") == yTypeFloat
+    assert guessType("+5e5") == yTypeFloat
+    assert guessType("-5e5") == yTypeFloat
+    assert guessType("5e+5") == yTypeFloat
+    assert guessType("+5e+5") == yTypeFloat
+    assert guessType("-5e+5") == yTypeFloat
+    assert guessType("5e-5") == yTypeFloat
+    assert guessType("+5e-5") == yTypeFloat
+    assert guessType("-5e-5") == yTypeFloat
+
+    assert guessType("5e05") == yTypeFloat
+    assert guessType("+5e05") == yTypeFloat
+    assert guessType("-5e05") == yTypeFloat
+    assert guessType("5e+05") == yTypeFloat
+    assert guessType("+5e+05") == yTypeFloat
+    assert guessType("-5e+05") == yTypeFloat
+    assert guessType("5e-05") == yTypeFloat
+    assert guessType("+5e-05") == yTypeFloat
+    assert guessType("-5e-05") == yTypeFloat
+
+    assert guessType("05e5") == yTypeFloat
+    assert guessType("+05e5") == yTypeFloat
+    assert guessType("-05e5") == yTypeFloat
+    assert guessType("05e+5") == yTypeFloat
+    assert guessType("+05e+5") == yTypeFloat
+    assert guessType("-05e+5") == yTypeFloat
+    assert guessType("05e-5") == yTypeFloat
+    assert guessType("+05e-5") == yTypeFloat
+    assert guessType("-05e-5") == yTypeFloat
+
+    assert guessType("05e05") == yTypeFloat
+    assert guessType("+05e05") == yTypeFloat
+    assert guessType("-05e05") == yTypeFloat
+    assert guessType("05e+05") == yTypeFloat
+    assert guessType("+05e+05") == yTypeFloat
+    assert guessType("-05e+05") == yTypeFloat
+    assert guessType("05e-05") == yTypeFloat
+    assert guessType("+05e-05") == yTypeFloat
+    assert guessType("-05e-05") == yTypeFloat
+
+  test "Non-Floats":
+    assert guessType(".") != yTypeFloat
+    assert guessType("+.") != yTypeFloat
+    assert guessType("-.") != yTypeFloat
+    assert guessType(".e4") != yTypeFloat
+    assert guessType("+.e4") != yTypeFloat
+    assert guessType("-.e4") != yTypeFloat
+
+  test "Bool-True":
+    assert guessType("y") == yTypeBoolTrue
+    assert guessType("Y") == yTypeBoolTrue
+    assert guessType("yes") == yTypeBoolTrue
+    assert guessType("Yes") == yTypeBoolTrue
+    assert guessType("true") == yTypeBoolTrue
+    assert guessType("True") == yTypeBoolTrue
+    assert guessType("on") == yTypeBoolTrue
+    assert guessType("On") == yTypeBoolTrue
+
+  test "Bool-False":
+    assert guessType("n") == yTypeBoolFalse
+    assert guessType("N") == yTypeBoolFalse
+    assert guessType("no") == yTypeBoolFalse
+    assert guessType("No") == yTypeBoolFalse
+    assert guessType("false") == yTypeBoolFalse
+    assert guessType("False") == yTypeBoolFalse
+    assert guessType("off") == yTypeBoolFalse
+    assert guessType("Off") == yTypeBoolFalse
+
+  test "Non-Bools":
+    assert guessType("ye") != yTypeBoolTrue
+    assert guessType("yse") != yTypeBoolTrue
+    # assert guessType("nO") != yTypeBoolFalse
+    assert guessType("flase") != yTypeBoolFalse

--- a/yaml/hints.nim
+++ b/yaml/hints.nim
@@ -23,6 +23,8 @@ type
     ## You can use it to determine the type of YAML scalars that have a '?'
     ## non-specific tag, but using this feature is completely optional.
     ##
+    ## See also: https://yaml.org/spec/1.2.2/#103-core-schema
+    ##
     ## ================== =========================
     ## Name               RegEx
     ## ================== =========================
@@ -30,9 +32,9 @@ type
     ## ``yTypeFloat``     ``[-+]? ( \. [0-9]+ | [0-9]+ ( \. [0-9]* )? ) ( [eE] [-+]? [0-9]+ )?``
     ## ``yTypeFloatInf``  ``[-+]? ( \.inf | \.Inf | \.INF )``
     ## ``yTypeFloatNaN``  ``\.nan | \.NaN | \.NAN``
-    ## ``yTypeBoolTrue``  ``y|Y|yes|Yes|YES|true|True|TRUE|on|On|ON`` (and all upper/lower variants)
-    ## ``yTypeBoolFalse`` ``n|N|no|No|NO|false|False|FALSE|off|Off|OFF``  (and all upper/lower variants)
-    ## ``yTypeNull``      ``~ | null | Null | NULL`` (and all upper/lower variants)
+    ## ``yTypeBoolTrue``  ``true | True | TRUE``
+    ## ``yTypeBoolFalse`` ``false | False | FALSE``
+    ## ``yTypeNull``      ``null | Null | NULL | ~``
     ## ``yTypeTimestamp`` see `here <http://yaml.org/type/timestamp.html>`_.
     ## ``yTypeUnknown``   ``*``
     ## ================== =========================
@@ -112,119 +114,119 @@ template advanceTypeHint(ch: char) {.dirty.} =
   of '.':
     [ythInt1, ythInt2, ythInt3, ythInt4, ythInt] => ythDecimal
     [ythInitial, ythMinus, ythPlus] => ythPoint
-    ythSecond2 => ythFraction
+    ythSecond2                      => ythFraction
   of '+':
-    ythInitial => ythPlus
-    ythNumE => ythNumEPlusMinus
+    ythInitial                => ythPlus
+    ythNumE                   => ythNumEPlusMinus
     [ythFraction, ythSecond2] => ythAfterTimePlusMinus
   of '-':
-    ythInitial => ythMinus
-    ythNumE => ythNumEPlusMinus
-    ythInt4 => ythYearMinus
-    ythMonth1 => ythMonthMinusNoYmd
-    ythMonth2 => ythMonthMinus
+    ythInitial                => ythMinus
+    ythNumE                   => ythNumEPlusMinus
+    ythInt4                   => ythYearMinus
+    ythMonth1                 => ythMonthMinusNoYmd
+    ythMonth2                 => ythMonthMinus
     [ythFraction, ythSecond2] => ythAfterTimePlusMinus
   of '_':
     [ythInt1, ythInt2, ythInt3, ythInt4] => ythInt
-    [ythInt, ythDecimal] => nil
+    [ythInt, ythDecimal]      => nil
   of ':':
-    [ythHour1, ythHour2] => ythHourColon
-    ythMinute2 => ythMinuteColon
-    [ythTzHour1, ythTzHour2] => ythTzHourColon
+    [ythHour1, ythHour2]      => ythHourColon
+    ythMinute2                => ythMinuteColon
+    [ythTzHour1, ythTzHour2]  => ythTzHourColon
   of '0'..'9':
-    ythInitial => ythInt1
-    ythInt1 => ythInt2
-    ythInt2 => ythInt3
-    ythInt3 => ythInt4
-    [ythInt4, ythMinus, ythPlus] => ythInt
-    [ythNumE, ythNumEPlusMinus] => ythExponent
-    ythYearMinus => ythMonth1
-    ythMonth1 => ythMonth2
-    ythMonthMinus => ythDay1
-    ythMonthMinusNoYmd => ythDay1NoYmd
-    ythDay1 => ythDay2
-    ythDay1NoYmd => ythDay2NoYmd
-    [ythAfterDaySpace, ythAfterDayT] => ythHour1
-    ythHour1 => ythHour2
-    ythHourColon => ythMinute1
-    ythMinute1 => ythMinute2
-    ythMinuteColon => ythSecond1
-    ythSecond1 => ythSecond2
-    ythAfterTimePlusMinus => ythTzHour1
-    ythTzHour1 => ythTzHour2
-    ythTzHourColon => ythTzMinute1
-    ythTzMinute1 => ythTzMinute2
-    ythPoint => ythDecimal
+    ythInitial                        => ythInt1
+    ythInt1                           => ythInt2
+    ythInt2                           => ythInt3
+    ythInt3                           => ythInt4
+    [ythInt4, ythMinus, ythPlus]      => ythInt
+    [ythNumE, ythNumEPlusMinus]       => ythExponent
+    ythYearMinus                      => ythMonth1
+    ythMonth1                         => ythMonth2
+    ythMonthMinus                     => ythDay1
+    ythMonthMinusNoYmd                => ythDay1NoYmd
+    ythDay1                           => ythDay2
+    ythDay1NoYmd                      => ythDay2NoYmd
+    [ythAfterDaySpace, ythAfterDayT]  => ythHour1
+    ythHour1                          => ythHour2
+    ythHourColon                      => ythMinute1
+    ythMinute1                        => ythMinute2
+    ythMinuteColon                    => ythSecond1
+    ythSecond1                        => ythSecond2
+    ythAfterTimePlusMinus             => ythTzHour1
+    ythTzHour1                        => ythTzHour2
+    ythTzHourColon                    => ythTzMinute1
+    ythTzMinute1                      => ythTzMinute2
+    ythPoint                          => ythDecimal
     [ythInt, ythDecimal, ythExponent, ythFraction] => nil
   of 'a':
-    ythF => ythLowerFA
-    ythPointN => ythPointNA
+    ythF           => ythLowerFA
+    ythPointN      => ythPointNA
     ythPointLowerN => ythPointLowerNA
   of 'A':
-    ythF => ythFA
+    ythF      => ythFA
     ythPointN => ythPointNA
   of 'e':
     [ythInt, ythDecimal,
       ythInt1, ythInt2, ythInt3, ythInt4] => ythNumE
     ythLowerFALS => ythFALSE
-    ythLowerTRU => ythTRUE
-    ythY => ythLowerYE
+    ythLowerTRU  => ythTRUE
+    ythY         => ythLowerYE
   of 'E':
     [ythInt, ythDecimal,
       ythInt1, ythInt2, ythInt3, ythInt4] => ythNumE
     ythFALS => ythFALSE
-    ythTRU => ythTRUE
-    ythY => ythYE
+    ythTRU  => ythTRUE
+    ythY    => ythYE
   of 'f':
-    ythInitial => ythF
-    ythO => ythLowerOF
-    ythLowerOF => ythOFF
+    ythInitial      => ythF
+    ythO            => ythLowerOF
+    ythLowerOF      => ythOFF
     ythPointLowerIN => ythPointINF
   of 'F':
     ythInitial => ythF
-    ythO => ythOF
-    ythOF => ythOFF
+    ythO       => ythOF
+    ythOF      => ythOFF
     ythPointIN => ythPointINF
   of 'i', 'I': ythPoint => ythPointI
   of 'l':
-    ythLowerNU => ythLowerNUL
+    ythLowerNU  => ythLowerNUL
     ythLowerNUL => ythNULL
-    ythLowerFA => ythLowerFAL
+    ythLowerFA  => ythLowerFAL
   of 'L':
-    ythNU => ythNUL
+    ythNU  => ythNUL
     ythNUL => ythNULL
-    ythFA => ythFAL
+    ythFA  => ythFAL
   of 'n':
-    ythInitial => ythN
-    ythO => ythON
-    ythPoint => ythPointLowerN
-    ythPointI => ythPointLowerIN
+    ythInitial      => ythN
+    ythO            => ythON
+    ythPoint        => ythPointLowerN
+    ythPointI       => ythPointLowerIN
     ythPointLowerNA => ythPointNAN
   of 'N':
     ythInitial => ythN
-    ythO => ythON
-    ythPoint => ythPointN
-    ythPointI => ythPointIN
+    ythO       => ythON
+    ythPoint   => ythPointN
+    ythPointI  => ythPointIN
     ythPointNA => ythPointNAN
   of 'o', 'O':
     ythInitial => ythO
-    ythN => ythNO
+    ythN       => ythNO
   of 'r': ythT => ythLowerTR
   of 'R': ythT => ythTR
   of 's':
     ythLowerFAL => ythLowerFALS
-    ythLowerYE => ythYES
+    ythLowerYE  => ythYES
   of 'S':
     ythFAL => ythFALS
-    ythYE => ythYES
+    ythYE  => ythYES
   of 't', 'T':
-    ythInitial => ythT
+    ythInitial         => ythT
     [ythDay1, ythDay2, ythDay1NoYmd, ythDay2NoYmd] => ythAfterDayT
   of 'u':
-    ythN => ythLowerNU
+    ythN       => ythLowerNU
     ythLowerTR => ythLowerTRU
   of 'U':
-    ythN => ythNU
+    ythN  => ythNU
     ythTR => ythTRU
   of 'y', 'Y': ythInitial => ythY
   of 'Z': [ythSecond2, ythFraction, ythAfterTimeSpace] => ythAfterTimeZ

--- a/yaml/hints.nim
+++ b/yaml/hints.nim
@@ -45,22 +45,17 @@ type
     ythInitial,
     ythF, ythFA, ythFAL, ythFALS, ythFALSE,
     ythN, ythNU, ythNUL, ythNULL,
-          ythNO,
-    ythO, ythON,
-          ythOF, ythOFF,
     ythT, ythTR, ythTRU, ythTRUE,
-    ythY, ythYE, ythYES,
 
     ythPoint, ythPointI, ythPointIN, ythPointINF,
               ythPointN, ythPointNA, ythPointNAN,
 
-    ythLowerFA, ythLowerFAL, ythLowerFALS,
-    ythLowerNU, ythLowerNUL,
-    ythLowerOF,
-    ythLowerTR, ythLowerTRU,
-    ythLowerYE,
+    ythLowerF, ythLowerFA, ythLowerFAL, ythLowerFALS,
+    ythLowerN, ythLowerNU, ythLowerNUL,
+    ythLowerT, ythLowerTR, ythLowerTRU,
 
-    ythPointLowerIN, ythPointLowerN, ythPointLowerNA,
+    ythPointLowerI, ythPointLowerIN,
+    ythPointLowerN, ythPointLowerNA,
 
     ythMinus, ythPlus, ythInt1, ythInt2, ythInt3, ythInt4, ythInt,
     ythDecimal, ythNumE, ythNumEPlusMinus, ythExponent,
@@ -159,9 +154,9 @@ template advanceTypeHint(ch: char) {.dirty.} =
     ythPoint                          => ythDecimal
     [ythInt, ythDecimal, ythExponent, ythFraction] => nil
   of 'a':
-    ythF           => ythLowerFA
-    ythPointN      => ythPointNA
-    ythPointLowerN => ythPointLowerNA
+    [ythF, ythLowerF] => ythLowerFA
+    ythPointN         => ythPointNA
+    ythPointLowerN    => ythPointLowerNA
   of 'A':
     ythF      => ythFA
     ythPointN => ythPointNA
@@ -170,24 +165,19 @@ template advanceTypeHint(ch: char) {.dirty.} =
       ythInt1, ythInt2, ythInt3, ythInt4] => ythNumE
     ythLowerFALS => ythFALSE
     ythLowerTRU  => ythTRUE
-    ythY         => ythLowerYE
   of 'E':
     [ythInt, ythDecimal,
       ythInt1, ythInt2, ythInt3, ythInt4] => ythNumE
     ythFALS => ythFALSE
     ythTRU  => ythTRUE
-    ythY    => ythYE
   of 'f':
-    ythInitial      => ythF
-    ythO            => ythLowerOF
-    ythLowerOF      => ythOFF
+    ythInitial      => ythLowerF
     ythPointLowerIN => ythPointINF
   of 'F':
     ythInitial => ythF
-    ythO       => ythOF
-    ythOF      => ythOFF
     ythPointIN => ythPointINF
-  of 'i', 'I': ythPoint => ythPointI
+  of 'i': ythPoint => ythPointLowerI
+  of 'I': ythPoint => ythPointI
   of 'l':
     ythLowerNU  => ythLowerNUL
     ythLowerNUL => ythNULL
@@ -197,38 +187,33 @@ template advanceTypeHint(ch: char) {.dirty.} =
     ythNUL => ythNULL
     ythFA  => ythFAL
   of 'n':
-    ythInitial      => ythN
-    ythO            => ythON
+    ythInitial      => ythLowerN
     ythPoint        => ythPointLowerN
-    ythPointI       => ythPointLowerIN
+    [ythPointI, ythPointLowerI] => ythPointLowerIN
     ythPointLowerNA => ythPointNAN
   of 'N':
     ythInitial => ythN
-    ythO       => ythON
     ythPoint   => ythPointN
     ythPointI  => ythPointIN
     ythPointNA => ythPointNAN
-  of 'o', 'O':
-    ythInitial => ythO
-    ythN       => ythNO
-  of 'r': ythT => ythLowerTR
+  of 'r': [ythT, ythLowerT] => ythLowerTR
   of 'R': ythT => ythTR
   of 's':
     ythLowerFAL => ythLowerFALS
-    ythLowerYE  => ythYES
   of 'S':
     ythFAL => ythFALS
-    ythYE  => ythYES
-  of 't', 'T':
+  of 't':
+    ythInitial         => ythLowerT
+    [ythDay1, ythDay2, ythDay1NoYmd, ythDay2NoYmd] => ythAfterDayT
+  of 'T':
     ythInitial         => ythT
     [ythDay1, ythDay2, ythDay1NoYmd, ythDay2NoYmd] => ythAfterDayT
   of 'u':
-    ythN       => ythLowerNU
-    ythLowerTR => ythLowerTRU
+    [ythN, ythLowerN]  => ythLowerNU
+    ythLowerTR         => ythLowerTRU
   of 'U':
     ythN  => ythNU
     ythTR => ythTRU
-  of 'y', 'Y': ythInitial => ythY
   of 'Z': [ythSecond2, ythFraction, ythAfterTimeSpace] => ythAfterTimeZ
   of ' ', '\t':
     [ythSecond2, ythFraction] => ythAfterTimeSpace
@@ -242,8 +227,8 @@ proc guessType*(scalar: string): TypeHint {.raises: [].} =
   for c in scalar: advanceTypeHint(c)
   case typeHintState
   of ythNULL, ythInitial: result = yTypeNull
-  of ythTRUE, ythON, ythYES, ythY: result = yTypeBoolTrue
-  of ythFALSE, ythOFF, ythNO, ythN: result = yTypeBoolFalse
+  of ythTRUE: result = yTypeBoolTrue
+  of ythFALSE: result = yTypeBoolFalse
   of ythInt1, ythInt2, ythInt3, ythInt4, ythInt: result = yTypeInteger
   of ythDecimal, ythExponent: result = yTypeFloat
   of ythPointINF: result = yTypeFloatInf


### PR DESCRIPTION
The regex's that were used for hinting were not aligned with the YAML 1.2.2 schema, see
   https://yaml.org/spec/1.2.2/#103-core-schema

Especially, leading zeros are no longer treated specially.

This commit updates the regex's used for integers and floats, update the state machine and adds some tests for the hinting.