### PR TITLE
Test supported versions

### DIFF
--- a/.github/workflows/action.yml
+++ b/.github/workflows/action.yml
@@ -12,6 +12,8 @@ jobs:
           - windows-latest
           - macOS-latest
         nim-version:
+          - '1.4.x'
+          - '1.6.x'
           - stable
           - devel
     steps:

--- a/.github/workflows/action.yml
+++ b/.github/workflows/action.yml
@@ -12,7 +12,6 @@ jobs:
           - windows-latest
           - macOS-latest
         nim-version:
-          - '1.4.x'
           - '1.6.x'
           - stable
           - devel


### PR DESCRIPTION
Per readme, NimYAML supports Nim 1.4.0+ - this CI change keeps the readme honest.