### PR TITLE
Export yaml specific exceptions that are part of API

### DIFF
--- a/yaml/loading.nim
+++ b/yaml/loading.nim
@@ -14,7 +14,7 @@
 
 import std / [ streams ]
 import native, parser, private/internal
-export native
+export native, YamlConstructionError, YamlParserError
 
 proc load*[K](input: Stream | string, target: var K)
     {.raises: [YamlConstructionError, IOError, OSError, YamlParserError].} =

--- a/yaml/tojson.nim
+++ b/yaml/tojson.nim
@@ -14,6 +14,8 @@
 import json, streams, strutils, tables
 import data, hints, native, stream, private/internal, parser
 
+export YamlConstructionError, YamlParserError
+
 # represents a single YAML level. The `node` with name `key`.
 # `expKey` is used to indicate that an empty node shall be filled
 type Level = tuple[node: JsonNode, key: string, expKey: bool]


### PR DESCRIPTION
`YamlConstructionError` and `YamlParserError` are part of the function signatures in those modules and thus they should be re-exported imo. Else you need to import specific modules to be able to access them.