### PR TITLE
fix error when atomicArc shallowCopy is not defined

### DIFF
--- a/yaml/dom.nim
+++ b/yaml/dom.nim
@@ -164,10 +164,11 @@ proc constructChild*(
       c.refs[target] = (tag: yamlTag(YamlNode), p: cast[pointer](result))
 
   var start: Event
-  when defined(gcArc) or defined(gcOrc) or defined(gcAtomicArc):
-    start = ctx.input.next()
-  else:
+  # instead of checking whether gcArc, gcOrc, or gcAtomicArc are defined, we use compiles to make it future proof. note that shallowCopy is only defined when for mm:arc/orc/atomicArc
+  when compiles(shallowCopy(start, ctx.input.next())):
     shallowCopy(start, ctx.input.next())
+  else:
+    start = ctx.input.next()
 
   case start.kind
   of yamlStartMap:
@@ -213,10 +214,10 @@ proc constructChild*(
       endPos: start.endPos,
     )
     ctx.addAnchor(start.scalarProperties.anchor)
-    when defined(gcArc) or defined(gcOrc) or defined(gcAtomicArc):
-      result.content = move start.scalarContent
-    else:
+    when compiles(shallowCopy(result.content, start.scalarContent)):
       shallowCopy(result.content, start.scalarContent)
+    else:
+      result.content = move start.scalarContent
   of yamlAlias:
     result = cast[YamlNode](ctx.refs.getOrDefault(start.aliasTarget).p)
   else: internalError("Malformed YamlStream")

--- a/yaml/dom.nim
+++ b/yaml/dom.nim
@@ -164,7 +164,7 @@ proc constructChild*(
       c.refs[target] = (tag: yamlTag(YamlNode), p: cast[pointer](result))
 
   var start: Event
-  when defined(gcArc) or defined(gcOrc):
+  when defined(gcArc) or defined(gcOrc) or defined(gcAtomicArc):
     start = ctx.input.next()
   else:
     shallowCopy(start, ctx.input.next())
@@ -213,7 +213,7 @@ proc constructChild*(
       endPos: start.endPos,
     )
     ctx.addAnchor(start.scalarProperties.anchor)
-    when defined(gcArc) or defined(gcOrc):
+    when defined(gcArc) or defined(gcOrc) or defined(gcAtomicArc):
       result.content = move start.scalarContent
     else:
       shallowCopy(result.content, start.scalarContent)

--- a/yaml/tojson.nim
+++ b/yaml/tojson.nim
@@ -70,7 +70,7 @@ proc jsonFromScalar(
       result = JsonNode(kind: JNull)
     else:
       result = JsonNode(kind: JString)
-      when defined(gcArc) or defined(gcOrc):
+      when defined(gcArc) or defined(gcOrc) or defined(gcAtomicArc):
         result.str = content
       else:
         shallowCopy(result.str, content)

--- a/yaml/tojson.nim
+++ b/yaml/tojson.nim
@@ -70,10 +70,10 @@ proc jsonFromScalar(
       result = JsonNode(kind: JNull)
     else:
       result = JsonNode(kind: JString)
-      when defined(gcArc) or defined(gcOrc) or defined(gcAtomicArc):
-        result.str = content
-      else:
+      when compiles(shallowCopy(result.str, content)): # instead of checking whether gcArc, gcOrc, or gcAtomicArc are defined, we use compiles to make it future proof. note that shallowCopy is only defined when for mm:arc/orc/atomicArc
         shallowCopy(result.str, content)
+      else:
+        result.str = content
   except ValueError as ve:
     var e = newException(YamlConstructionError, "Cannot parse numeric value")
     e.parent = ve


### PR DESCRIPTION
when compile with `mm:atomicArc`, will get error : 'shallowCopy is not defined'. 